### PR TITLE
Make sure redis.conf belongs to user redis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM redis:alpine
 COPY redis.conf /usr/local/etc/redis/redis.conf
+RUN chown redis /usr/local/etc/redis/redis.conf
 CMD [ "redis-server", "/usr/local/etc/redis/redis.conf" ]


### PR DESCRIPTION
I was deploying redis using this project and the next error showed up:

 # Fatal error, can't open config file '/usr/local/etc/redis/redis.conf'

After reading the redis:alpine dockerfile, I realized it was a permission error given wrong user: root instead of redis. Docker copy uses root by default.