### PR TITLE
Update to Redis 6.0.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM redis:3.2.12-alpine3.8
+FROM redis:6.0.6-alpine3.12
 COPY redis.conf /usr/local/etc/redis/redis.conf
 CMD [ "redis-server", "/usr/local/etc/redis/redis.conf" ]

--- a/redis.conf
+++ b/redis.conf
@@ -1,6 +1,7 @@
 # AOF Persistence
 appendonly yes
 appendfilename "appendonly.aof"
+appendfsync no
 auto-aof-rewrite-percentage 50
 auto-aof-rewrite-min-size 64mb
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR updates Redis `6.0.6` and Alpine to `3.12`. It also disables the manual `fsync` that Redis does every second on the AOF.

Previous comment on why I propose to disable this:
> The default `appendfsync` setting is `everysec` which means that Redis will attempt to flush the AOF every second using `fsync`. With `no`, we allow the operating system to decide when to flush to disk when it considers to be more beneficial. This reduces a bit of our failure resilience, but ensure that we don't choke the HDD every second when traffic is (too) high. Our issue is also worse since all 3 Redis instances will do it every second, choking one another. Redis does not allow anything else than `everysec`, `no` and `always`, no specific timing or with jitter :disappointed:.